### PR TITLE
Fix missing emit and incorrect VfsFile path in AndroidResourcesVfs

### DIFF
--- a/korlibs-io/src@android/io/file/std/VfsAndroid.kt
+++ b/korlibs-io/src@android/io/file/std/VfsAndroid.kt
@@ -76,12 +76,12 @@ class AndroidResourcesVfs : Vfs() {
 
     override suspend fun listFlow(path: String): Flow<VfsFile> {
         val context = androidContext()
-        return flow<VfsFile> {
+        return flow {
             val rpath = path.trim('/')
-            val files = context.assets.list(rpath)?.toList() ?: emptyList()
+            val files = context.assets.list(rpath).orEmpty()
             //println("AndroidResourcesVfs.listSimple: path=$path, rpath=$rpath")
             //println(" -> $files")
-            files.map { file(it) }
+            files.forEach { emit(file("$rpath/$it")) }
         }.flowOn(Dispatchers.CIO)
     }
 


### PR DESCRIPTION
Hello! Thanks for all the work you've done on Korlibs.

I was working with the `AndroidResourcesVfs` through `standardVfs.resourcesVfs` and noticed `list()` was not listing any files. It looks like the `flow {}` builder was missing the `emit` statement, so I added that. Also the results of `AssetManager.list` are file names relative to `rpath` so I fixed the creation of the `VfsFile` to account for that.